### PR TITLE
Update dependencies to only depend on rspec-core

### DIFF
--- a/rspec-retry.gemspec
+++ b/rspec-retry.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "rspec-retry"
   gem.require_paths = ["lib"]
   gem.version       = RSpec::Retry::VERSION
-  gem.add_runtime_dependency %{rspec}
+  gem.add_runtime_dependency %{rspec-core}
   gem.add_development_dependency %q{guard-rspec}
   gem.add_development_dependency %q{pry-debugger}
 end


### PR DESCRIPTION
Fixes incompatibility with minitest/spec.