### PR TITLE
Uses 'try' instead of 'retry' in where 'retry' can be misleading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # RSpec::Retry
 
-RSpec::Retry adds ``:retry`` option to rspec example.
+RSpec::Retry adds ``:try`` option to rspec example.
 It is for randomly failing example.
-If example has ``:retry``, rspec retry specified times until success.
+If example has ``:try``, rspec retry specified times until success.
 
 ## Installation
 
@@ -32,11 +32,11 @@ end
 ## Usage
 
 ```ruby
-it 'should randomly success', :retry => 3 do
+it 'should randomly success', :try => 3 do
   rand(2).should == 1
 end
 
-it 'should succeed after a while', :retry => 3, :retry_wait=>10 do
+it 'should succeed after a while', :try => 3, :retry_wait=>10 do
   command('service myservice status').should == 'started'
 end
 # run spec (following log is shown if verbose_retry options is true)
@@ -47,7 +47,7 @@ end
 ## Configuration
 
 - __:verbose_retry__(default: *false*) Print retry status
-- __:default_retry_count__(default: *1*) If retry count is not set in example, this value is used by default
+- __:default_try_count__(default: *1*) If try count is not set in example, this value is used by default
 - __:retry_wait__(default: *0*) Seconds to wait between retries
 - __:clear_lets_on_failure__(default: *true*) Clear memoized value for ``let`` before retrying
 

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -7,7 +7,7 @@ module RSpec
     def self.apply
       RSpec.configure do |config|
         config.add_setting :verbose_retry, :default => false
-        config.add_setting :default_retry_count, :default => 1
+        config.add_setting :default_try_count, :default => 1
         config.add_setting :default_sleep_interval, :default => 0
         config.add_setting :clear_lets_on_failure, :default => true
 
@@ -18,13 +18,13 @@ module RSpec
 
         config.around(:each) do |ex|
           example = fetch_current_example.call(self)
-          retry_count = ex.metadata[:retry] || RSpec.configuration.default_retry_count
+          try_count = ex.metadata[:try] || RSpec.configuration.default_try_count
           sleep_interval = ex.metadata[:retry_wait] || RSpec.configuration.default_sleep_interval
 
           clear_lets = ex.metadata[:clear_lets_on_failure]
           clear_lets = RSpec.configuration.clear_lets_on_failure if clear_lets.nil?
 
-          retry_count.times do |i|
+          try_count.times do |i|
             if RSpec.configuration.verbose_retry?
               if i > 0
                 message = "RSpec::Retry: #{RSpec::Retry.ordinalize(i + 1)} try #{example.location}"

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -31,7 +31,7 @@ describe RSpec::Retry do
     context do
       before(:all) { set_expectations([false, false, true]) }
 
-      it 'should run example until :retry times', :retry => 3 do
+      it 'should run example until :retry times', :try => 3 do
         true.should == shift_expectation
         count.should == 3
       end
@@ -40,7 +40,7 @@ describe RSpec::Retry do
     context do
       before(:all) { set_expectations([false, true, false]) }
 
-      it 'should stop retrying if  example is succeeded', :retry => 3 do
+      it 'should stop retrying if  example is succeeded', :try => 3 do
         true.should == shift_expectation
         count.should == 2
       end
@@ -58,11 +58,11 @@ describe RSpec::Retry do
       @control = false
     end
 
-    it 'should clear the let when the test fails so it can be reset', :retry => 2 do
+    it 'should clear the let when the test fails so it can be reset', :try => 2 do
       let_based_on_control.should == false
     end
 
-    it 'should not clear the let when the test fails', :retry => 2, :clear_lets_on_failure => false do
+    it 'should not clear the let when the test fails', :try => 2, :clear_lets_on_failure => false do
       let_based_on_control.should == !@control
     end
   end


### PR DESCRIPTION
[edited: changed 'attempt' to 'try' to keep with the 'respec-retry' theme] When using this gem, I first set my default_retry_count variable to 0, because I didn't want any retries locally. It took me a while to realize rspec was skipping my tests; using 'try' instead might be less misleading :)