### PR TITLE
Add option to restrict retries to a list of Exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ end
 
 ```ruby
 it 'should randomly success', :retry => 3 do
-  rand(2).should == 1
+  expect(rand(2)).to eq(1)
 end
 
 it 'should succeed after a while', :retry => 3, :retry_wait=>10 do
-  command('service myservice status').should == 'started'
+  expect(command('service myservice status')).to eq('started')
 end
 # run spec (following log is shown if verbose_retry options is true)
 # RSpec::Retry: 2nd try ./spec/lib/random_spec.rb:49
@@ -50,6 +50,7 @@ end
 - __:default_retry_count__(default: *1*) If retry count is not set in example, this value is used by default
 - __:retry_wait__(default: *0*) Seconds to wait between retries
 - __:clear_lets_on_failure__(default: *true*) Clear memoized value for ``let`` before retrying
+- __:exceptions_to_retry__(default: *[]*) List of exceptions that will trigger a retry (when empty, all exceptions will)
 
 ## Contributing
 

--- a/rspec-retry.gemspec
+++ b/rspec-retry.gemspec
@@ -16,5 +16,9 @@ Gem::Specification.new do |gem|
   gem.version       = RSpec::Retry::VERSION
   gem.add_runtime_dependency %{rspec}
   gem.add_development_dependency %q{guard-rspec}
-  gem.add_development_dependency %q{pry-debugger}
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2')
+    gem.add_development_dependency %q{pry-debugger}
+  else
+    gem.add_development_dependency %q{pry-byebug}
+  end
 end

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -45,6 +45,22 @@ describe RSpec::Retry do
         expect(count).to eq(2)
       end
     end
+
+    describe "with a list of exceptions", :retry => 2, :exceptions_to_retry => [NoMethodError] do
+      context "the example throws an exception contained in the retry list" do
+        it "retries the maximum number of times" do
+          raise NoMethodError unless count > 1
+          expect(count).to eq(2)
+        end
+      end
+
+      context "the example fails (with an exception not in the retry list)" do
+        it "only runs once" do
+          set_expectations([false])
+          expect(count).to eq(1)
+        end
+      end
+    end
   end
 
   describe 'clearing lets' do

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -21,7 +21,7 @@ describe RSpec::Retry do
 
   context 'no retry option' do
     it 'should work' do
-      true.should be true
+      expect(true).to be(true)
     end
   end
 
@@ -32,8 +32,8 @@ describe RSpec::Retry do
       before(:all) { set_expectations([false, false, true]) }
 
       it 'should run example until :retry times', :retry => 3 do
-        true.should == shift_expectation
-        count.should == 3
+        expect(true).to be(shift_expectation)
+        expect(count).to eq(3)
       end
     end
 
@@ -41,8 +41,8 @@ describe RSpec::Retry do
       before(:all) { set_expectations([false, true, false]) }
 
       it 'should stop retrying if  example is succeeded', :retry => 3 do
-        true.should == shift_expectation
-        count.should == 2
+        expect(true).to be(shift_expectation)
+        expect(count).to eq(2)
       end
     end
   end
@@ -59,11 +59,11 @@ describe RSpec::Retry do
     end
 
     it 'should clear the let when the test fails so it can be reset', :retry => 2 do
-      let_based_on_control.should == false
+      expect(let_based_on_control).to be(false)
     end
 
     it 'should not clear the let when the test fails', :retry => 2, :clear_lets_on_failure => false do
-      let_based_on_control.should == !@control
+      expect(let_based_on_control).to be(!@control)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 require 'rspec'
 require 'rspec/retry'
-require 'pry-debugger'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2')
+  require "pry-debugger"
+else
+  require "pry-byebug"
+end
 
 RSpec.configure do |config|
   config.verbose_retry = true


### PR DESCRIPTION
Current behaviour is only changed when a (non-empty) list of Exceptions is provided as `exceptions_to_retry`, in a similar manner as the other settings are.

When that happens (and `retry` or `default_retry_count` is > 1), we check if the Exception raised on the example matches any of the provided ones and if it doesn't, we immediately fail instead of retrying.

Also piggybacked some useful changes:
 - defaulted to using `pry-byebug` on Ruby 2.x
 - upgraded RSpec's syntax to the "expect" format